### PR TITLE
Dockerfile: upgrade all installed packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,10 @@ RUN \
     --usage-reporting=false \
     --bash-completion=false \
     --disable-installation-options \
+  # Upgrade all packages that are coming from the base
+  # gcr.io/cloud-builders/docker image.
+  && apt-get upgrade -y \
+  && apt-get dist-upgrade \
   # Clean up.
   && rm -rf \
     /var/lib/apt/lists/* \


### PR DESCRIPTION
This is to cover for the case where our base image has not been updated
for some time (gcr.io/cloud-builders/docker).

Tested by building gcr.io/louhi-test/k8s-addon-builder:latest just now, where I observed that the systemd package was updated from 229-4ubuntu21.9 to 229-4ubuntu21.22.

/cc @MartinPetkov 