### PR TITLE
add builder-tools/* scripts back to the PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN mkdir -pv \
 # Inject Golang.
 COPY --from=go $GOROOT $GOROOT
 
-ENV PATH="/k8s-addon-builder:/builder/google-cloud-sdk/bin:${GOROOT}/bin:${GOPATH}/bin:${INSTALL_GOPATH}/bin:/workspace/go/src/github.com/GoogleCloudPlatform/k8s-addon-builder/builder-tools:${PATH}"
+ENV PATH="/k8s-addon-builder:/builder/google-cloud-sdk/bin:${GOROOT}/bin:${GOPATH}/bin:${INSTALL_GOPATH}/bin:${PATH}"
 
 RUN \
   # Install common build tools.

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,6 +92,10 @@ RUN \
   && mv ko /bin
 
 RUN \
+  # Copy over builder-tools scripts to /k8s-addon-builder.
+  cp builder-tools/* /k8s-addon-builder
+
+RUN \
   # Clean up.
   rm -rf \
     /var/lib/apt/lists/* \


### PR DESCRIPTION
Before, we attempted to add these scripts into the PATH by simply
modifying the path to reflect /workspace/... within the Docker image's
filesystem. However this is a problem in Google Cloud Build because
/workspace becomes "empty" at the start of a build.

The solution is to just copy over the scripts into the top-level
/k8s-addon-builder folder, as they were done previously (prior to
665362d).